### PR TITLE
依赖问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 
 > python3 BypassFramework.py
 
+Linux遇到`sh: 1: i686-w64-mingw32-g++: not found`需要安装以下依赖  
+> sudo apt-get install mingw-w64
+
+
 **因为是linux下编译，所以编译文件会有体积大的问题，该工具为三天内的产物，可能有不少bug，欢迎在issus处与我反馈**
 
 


### PR DESCRIPTION
readme添加对`sh: 1: i686-w64-mingw32-g++: not found`的解决